### PR TITLE
ignore any errors from this GSS cleanup call

### DIFF
--- a/flask_kerberos.py
+++ b/flask_kerberos.py
@@ -82,8 +82,12 @@ def _gssapi_authenticate(token):
     except kerberos.GSSError:
         return None
     finally:
-        if state:
-            kerberos.authGSSServerClean(state)
+        # ignore any cleanup errors from GSS
+        try:
+            if state:
+                kerberos.authGSSServerClean(state)
+        except:
+            pass
 
 
 def requires_authentication(function):


### PR DESCRIPTION
Ignore any errors from this GSS call; currently they fail with Apple's pykerberos.
